### PR TITLE
Potential fix for code scanning alert no. 3: User-controlled bypass of sensitive method

### DIFF
--- a/src/IdentityProvider/Components/Account/Pages/Manage/ExternalLogins.razor
+++ b/src/IdentityProvider/Components/Account/Pages/Manage/ExternalLogins.razor
@@ -99,10 +99,17 @@
 
         showRemoveButton = passwordHash is not null || currentLogins.Count > 1;
 
-        if (HttpMethods.IsGet(HttpContext.Request.Method) && Action == LinkLoginCallbackAction)
+        if (HttpMethods.IsGet(HttpContext.Request.Method) && IsValidAction(Action))
         {
             await OnGetLinkLoginCallbackAsync();
         }
+    }
+
+    private bool IsValidAction(string? action)
+    {
+        // Add your validation logic here
+        // For example, check if the action is allowed and the user is authorized
+        return action == LinkLoginCallbackAction && UserManager.IsSignedIn(HttpContext.User);
     }
 
     private async Task OnSubmitAsync()


### PR DESCRIPTION
Potential fix for [https://github.com/Evilazaro/IdentityProvider/security/code-scanning/3](https://github.com/Evilazaro/IdentityProvider/security/code-scanning/3)

To fix the problem, we need to ensure that the `Action` parameter is validated and that the execution of the `OnGetLinkLoginCallbackAsync` method is properly authenticated and authorized. We can achieve this by adding a validation step to check if the user is authenticated and authorized to perform the action before executing the method.

1. Add a method to validate the `Action` parameter and ensure the user is authenticated and authorized.
2. Modify the `OnInitializedAsync` method to call this validation method before executing the `OnGetLinkLoginCallbackAsync` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
